### PR TITLE
Fix broken link to RH container registry

### DIFF
--- a/lab-02-docker.md
+++ b/lab-02-docker.md
@@ -30,7 +30,7 @@ Have a look at the Dockerfile of the base image!
 
 Hint: There are two well known public container registries:
 
-- [Official redhat registry](https://catalog.redhat.com/software/containers/)
+- [Official redhat registry](https://catalog.redhat.com/software/containers/search)
 - [Docker Hub](https://hub.docker.com/)
 
 Be aware, that everybody can upload images to Docker Hub, so use them with caution! All the images from the redhat registry are certified and should be used whenever possible.

--- a/lab-03-s2i-app-dev.md
+++ b/lab-03-s2i-app-dev.md
@@ -48,7 +48,7 @@ Fill in the following values:
 1. General
     * **Name:** `patient-ui`
 1. Advanced Options
-    * **Create a rout to the application:** [x] should be checked
+    * **Create a route to the application:** [x] should be checked
     ![Advanced options](lab-03-images/advanced-options.png)
     * **Build Configuration:**  
     Here you can specify when new builds should be launched.  


### PR DESCRIPTION
Fixed broken link to RH container registry, current one gave a "Not found"